### PR TITLE
Error detected in github link does not open due to bad link in https - website 

### DIFF
--- a/_includes/header.md
+++ b/_includes/header.md
@@ -1,6 +1,6 @@
 ## [Kareem Zidane](/)
 <kareemzidane2@gmail.com>\\
 [<i class="fab fa-facebook-square"></i>](https://facebook.com/kzidane2){:.pr-1}
-[<i class="fab fa-github-square"></i>](https://github.com.com/kzidane2){:.pr-1}
+[<i class="fab fa-github-square"></i>](https://github.com/kzidane){:.pr-1}
 [<i class="fab fa-linkedin"></i>](https://linkedin.com/in/kzidane1){:.pr-1}
 [<i class="fab fa-twitter-square"></i>](https://twitter.com/_kzidane){:.pr-1}


### PR DESCRIPTION
# Github link error profile - website https://kzidane.me

**File in _includes/header.md:** now is https://github.com.com/kzidane2
